### PR TITLE
fix #16 @Transactional をサービスで使用する

### DIFF
--- a/src/main/kotlin/com/thurofuji/expensesBook/service/ExpenseTypeService.kt
+++ b/src/main/kotlin/com/thurofuji/expensesBook/service/ExpenseTypeService.kt
@@ -5,6 +5,7 @@ import com.thurofuji.expensesBook.exception.InvalidExpenseTypeException
 import com.thurofuji.expensesBook.repository.ExpenseBookRepository
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * 費目に関するビジネスロジックを扱うServiceクラス
@@ -18,6 +19,7 @@ class ExpenseTypeService(private val repository: ExpenseBookRepository) {
      * @throws InvalidExpenseTypeException [code]に該当する有効な費目が見つからない場合にスローされる
      */
     @Cacheable("expenseTypes")
+    @Transactional(readOnly = true)
     fun getExpenseType(code: Int): ExpenseTypeDto = getValidExpenseTypes().firstOrNull { it.費目cd == code }
         ?: throw InvalidExpenseTypeException("Invalid code for expense type.: $code")
 

--- a/src/main/kotlin/com/thurofuji/expensesBook/service/ExpensesBookService.kt
+++ b/src/main/kotlin/com/thurofuji/expensesBook/service/ExpensesBookService.kt
@@ -5,6 +5,7 @@ import com.thurofuji.expensesBook.dto.ExpenseDto
 import com.thurofuji.expensesBook.mapper.ExpenseMapper
 import com.thurofuji.expensesBook.repository.ExpenseBookRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 /**
@@ -17,6 +18,7 @@ class ExpensesBookService(private val repository: ExpenseBookRepository
     /**
      * [yyyyMM]や[types]で指定された条件に該当する出費一覧を、[ExpenseDto]の[List]として返す。
      */
+    @Transactional(readOnly = true)
     fun findList(yyyyMM: String, types: List<Int>): List<ExpenseDto> {
         return repository.findList(mapper.toSearchCondition(yyyyMM, types))
             .map { mapper.toDto(it) }
@@ -26,6 +28,7 @@ class ExpensesBookService(private val repository: ExpenseBookRepository
      * 指定された[id]に合致する出費（[ExpenseDto]）を取得する。
      * 該当するものがなければnullを返す。
      */
+    @Transactional(readOnly = true)
     fun findDetail(id: UUID): ExpenseDto? {
         return repository.findDetail(id)?.let { mapper.toDto(it) }
     }
@@ -34,6 +37,7 @@ class ExpensesBookService(private val repository: ExpenseBookRepository
      * [request]で指定された出費の情報を[userId]の出費として登録する。
      * 戻り値として登録された出費（[ExpenseDto]）を返す。
      */
+    @Transactional
     fun register(request: ExpenseRequest, userId: String): ExpenseDto {
         return repository.register(mapper.toNewDto(userId, request))
     }
@@ -41,6 +45,7 @@ class ExpensesBookService(private val repository: ExpenseBookRepository
     /**
      * [id]で指定された出費を、[request]の内容へ[userId]の出費として更新し、更新された行数を返す。
      */
+    @Transactional
     fun update(id: UUID, request: ExpenseRequest, userId: String): Int {
         return repository.update(mapper.toDto(userId, id, request))
     }
@@ -48,6 +53,7 @@ class ExpensesBookService(private val repository: ExpenseBookRepository
     /**
      * [id]で指定された既存の出費を削除し、削除された行数を返す
      */
+    @Transactional
     fun delete(id: UUID): Int {
         return repository.delete(id)
     }


### PR DESCRIPTION
## 概要

下記のコミットメッセージに書いている通り。
Springで用意されているトランザクション管理の仕組みを有効にするため、`@Transactional`を付与。

意図的に例外を発生させたり、わざと`readOnly`なトランザクションで変更を行おうとしたりして、アノテーションによるトランザクション管理が効いていることは確認済み。

```
feat: Springでのトランザクション管理を有効にするため、`@Transactional`を付与する。例外発生時にロールバックされることや、`readOnly`の付与されたトランザクションで変更が行えないことは動作確認済み。
```
